### PR TITLE
Fixes bug in intersection due to changing precision

### DIFF
--- a/beziers/utils/intersectionsmixin.py
+++ b/beziers/utils/intersectionsmixin.py
@@ -1,6 +1,7 @@
 import sys
 from beziers.point import Point
 from beziers.utils import isclose
+from decimal import Decimal
 
 my_epsilon = 2e-7
 
@@ -125,8 +126,13 @@ class IntersectionsMixin:
         if this.bounds().overlaps(that.bounds()):
           found.extend(this._curve_curve_intersections_t(that, precision))
     seen = {}
+    numPrecisionDigits = abs(Decimal(str(precision)).as_tuple().exponent)
+
     def filterSeen(n):
-      key = '%.5f' % n[0]
+      # use (precision - 1) digits to check whether we have already
+      # seen this value
+      key = f"%.{numPrecisionDigits - 1}f" % n[0]
+
       if key in seen: return False
       seen[key] = 1
       return True


### PR DESCRIPTION
Changing precision from 6 digits to 3 digits broke the intersection code due to the hardcoded 5 digit uniqueness check. This resulted in multiple overlapping intersection points.  I've updated the uniqueness check to use numDigits - 1 precision. This fixes the tests, and seems to work well for digits 0-6.  Strangely, still broken for higher levels of precision.  (I didn't investigate further)